### PR TITLE
fix: Support `#` character as interpolation string in ICU messages plural forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Support `#` character as interpolation string in addition to `<x id="INTERPOLATION" />` tag in ICU messages plural forms
+
 ## [0.6.0] - 2023-07-13
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/vtabary/xliff2js",
   "license": "MIT",
   "dependencies": {
-    "@formatjs/icu-messageformat-parser": "^2.3.1",
+    "@formatjs/icu-messageformat-parser": "^2.7.0",
     "fast-xml-parser": "^4.2.2"
   },
   "devDependencies": {

--- a/src/xliff-parser/xliff-parser.spec.ts
+++ b/src/xliff-parser/xliff-parser.spec.ts
@@ -112,7 +112,10 @@ describe('XliffParser', () => {
   <file>
     <body>
       <trans-unit id="abcd">
-        <source>before {num_of_items, plural, =0 {no item} other {<x id="INTERPOLATION" />}} after</source>
+        <source>before {num_of_items, plural, =0 {no item} other {<x id="INTERPOLATION" /> items}} after</source>
+      </trans-unit>
+      <trans-unit id="efgh">
+        <source>before {num_of_items, plural, =0 {no item} other {# items}} after</source>
       </trans-unit>
     </body>
   </file>
@@ -163,7 +166,30 @@ describe('XliffParser', () => {
                                   children: [],
                                   name: 'x',
                                 },
+                                ' items',
                               ],
+                            },
+                          },
+                          ' after',
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    $: { id: 'efgh' },
+                    name: 'trans-unit',
+                    children: [
+                      {
+                        $: {},
+                        name: 'source',
+                        children: [
+                          'before ',
+                          {
+                            name: 'plural',
+                            key: 'num_of_items',
+                            counters: {
+                              '=0': ['no item'],
+                              other: ['# items'],
                             },
                           },
                           ' after',

--- a/src/xliff-parser/xliff-parser.ts
+++ b/src/xliff-parser/xliff-parser.ts
@@ -175,6 +175,11 @@ export class XliffParser {
     return this.convertNodes(parsedInterpolation) as any;
   }
 
+  /**
+   * Interpolation entity can be the XML tag `<x id="INTERPOLATION" />`
+   * or the `#` character if it is not escaped with single quotes e.g `'#'`
+   * @see https://unicode-org.github.io/icu/userguide/format_parse/messages/#quotingescaping
+   */
   private protectInterpolations(text: string): {
     source: string;
     replaced: string;
@@ -184,7 +189,7 @@ export class XliffParser {
 
     return {
       source: text,
-      replaced: text.replace(/<x[^>]+>/g, (value) => {
+      replaced: text.replace(/(<x[^>]+>)|((?<!')#)/g, (value) => {
         const index = interpolations.length;
         interpolations.push(value);
         return `__${index}__`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -996,35 +996,35 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.39.0.tgz#58b536bcc843f4cd1e02a7e6171da5c040f4d44b"
   integrity sha512-kf9RB0Fg7NZfap83B3QOqOGg9QmD9yBudqQXzzOtn3i4y7ZUXe5ONeW34Gwi+TxhH4mvj72R1Zc300KUMa9Bng==
 
-"@formatjs/ecma402-abstract@1.14.3":
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-1.14.3.tgz#6428f243538a11126180d121ce8d4b2f17465738"
-  integrity sha512-SlsbRC/RX+/zg4AApWIFNDdkLtFbkq3LNoZWXZCE/nHVKqoIJyaoQyge/I0Y38vLxowUn9KTtXgusLD91+orbg==
+"@formatjs/ecma402-abstract@1.17.2":
+  version "1.17.2"
+  resolved "https://artefacts.si.perfect-memory.com/repository/npm-all/@formatjs/ecma402-abstract/-/ecma402-abstract-1.17.2.tgz#d197c6e26b9fd96ff7ba3b3a0cc2f25f1f2dcac3"
+  integrity sha512-k2mTh0m+IV1HRdU0xXM617tSQTi53tVR2muvYOsBeYcUgEAyxV1FOC7Qj279th3fBVQ+Dj6muvNJZcHSPNdbKg==
   dependencies:
-    "@formatjs/intl-localematcher" "0.2.32"
+    "@formatjs/intl-localematcher" "0.4.2"
     tslib "^2.4.0"
 
-"@formatjs/icu-messageformat-parser@^2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.3.1.tgz#953080ea5c053bc73bdf55d0a524a3c3c133ae6b"
-  integrity sha512-knF2AkAKN4Upv4oIiKY4Wd/dLH68TNMPgV/tJMu/T6FP9aQwbv8fpj7U3lkyniPaNVxvia56Gxax8MKOjtxLSQ==
+"@formatjs/icu-messageformat-parser@^2.7.0":
+  version "2.7.0"
+  resolved "https://artefacts.si.perfect-memory.com/repository/npm-all/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.0.tgz#9b13f2710a3b4efddfeb544480f684f27a53483b"
+  integrity sha512-7uqC4C2RqOaBQtcjqXsSpGRYVn+ckjhNga5T/otFh6MgxRrCJQqvjfbrGLpX1Lcbxdm5WH3Z2WZqt1+Tm/cn/Q==
   dependencies:
-    "@formatjs/ecma402-abstract" "1.14.3"
-    "@formatjs/icu-skeleton-parser" "1.3.18"
+    "@formatjs/ecma402-abstract" "1.17.2"
+    "@formatjs/icu-skeleton-parser" "1.6.2"
     tslib "^2.4.0"
 
-"@formatjs/icu-skeleton-parser@1.3.18":
-  version "1.3.18"
-  resolved "https://registry.yarnpkg.com/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.3.18.tgz#7aed3d60e718c8ad6b0e64820be44daa1e29eeeb"
-  integrity sha512-ND1ZkZfmLPcHjAH1sVpkpQxA+QYfOX3py3SjKWMUVGDow18gZ0WPqz3F+pJLYQMpS2LnnQ5zYR2jPVYTbRwMpg==
+"@formatjs/icu-skeleton-parser@1.6.2":
+  version "1.6.2"
+  resolved "https://artefacts.si.perfect-memory.com/repository/npm-all/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.6.2.tgz#00303034dc08583973c8aa67b96534c49c0bad8d"
+  integrity sha512-VtB9Slo4ZL6QgtDFJ8Injvscf0xiDd4bIV93SOJTBjUF4xe2nAWOoSjLEtqIG+hlIs1sNrVKAaFo3nuTI4r5ZA==
   dependencies:
-    "@formatjs/ecma402-abstract" "1.14.3"
+    "@formatjs/ecma402-abstract" "1.17.2"
     tslib "^2.4.0"
 
-"@formatjs/intl-localematcher@0.2.32":
-  version "0.2.32"
-  resolved "https://registry.yarnpkg.com/@formatjs/intl-localematcher/-/intl-localematcher-0.2.32.tgz#00d4d307cd7d514b298e15a11a369b86c8933ec1"
-  integrity sha512-k/MEBstff4sttohyEpXxCmC3MqbUn9VvHGlZ8fauLzkbwXmVrEeyzS+4uhrvAk9DWU9/7otYWxyDox4nT/KVLQ==
+"@formatjs/intl-localematcher@0.4.2":
+  version "0.4.2"
+  resolved "https://artefacts.si.perfect-memory.com/repository/npm-all/@formatjs/intl-localematcher/-/intl-localematcher-0.4.2.tgz#7e6e596dbaf2f0c5a7c22da5a01d5c55f4c37e9a"
+  integrity sha512-BGdtJFmaNJy5An/Zan4OId/yR9Ih1OojFjcduX/xOvq798OgWSyDtd6Qd5jqJXwJs1ipe4Fxu9+cshic5Ox2tA==
   dependencies:
     tslib "^2.4.0"
 


### PR DESCRIPTION
Intend to support the use of `#` character as interpolation string in ICU messages plural forms.

What is badly supported for now is when one want to use the # character and it that should not be an interpolation character. (example: `There are # '#' in this text`) The first # should be interpolated, but the second should not, so it is escaped with single quotes. But the ICU parser removes the quotes. This seems to be an edge case for now, until it can be fixed or workaround.

Sources: 

- https://unicode-org.github.io/icu/userguide/format_parse/messages/#complex-argument-types
- https://formatjs.io/docs/icu-messageformat-parser/#example
- https://angular.io/api/common/I18nPluralPipe
